### PR TITLE
Check buffer is not read only when starting a review

### DIFF
--- a/org-srs-review.el
+++ b/org-srs-review.el
@@ -199,6 +199,7 @@
   "Start a review session with ARGS."
   (interactive)
   (require 'org-srs)
+  (cl-assert (not buffer-read-only) nil "Buffer must be editable.")
   (if-let ((item-and-id (org-srs-review-next-due-item)))
       (cl-destructuring-bind (item _id) item-and-id
         (apply #'org-srs-item-goto item-and-id)


### PR DESCRIPTION
I added this after opening `org-srs-example.org` in a read-only buffer with `magit-find-file` and then running `org-srs-review-start`.