### PR TITLE
Add form-feed character (page delimiter) at the bottom of README.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -194,3 +194,7 @@ variables are documented.
   | * | 2024-12-07T13:54:34Z |        |           |            |       |
   :END:
 #+END_SRC
+
+#+begin_comment
+
+#+end_comment


### PR DESCRIPTION
This causes Emacs to ignore the Local Variables list above, so that we aren't prompted to apply unsafe variables when opening README.org.

Resolves #7.