### PR TITLE
Add display of inline images

### DIFF
--- a/org-srs-item-card.el
+++ b/org-srs-item-card.el
@@ -136,6 +136,7 @@
   "Show the current flashcard entirely by unfolding the text and removing ellipses."
   (save-excursion
     (org-fold-show-subtree)
+    (org-display-inline-images t)
     (org-srs-item-card-remove-ellipsis-overlays)))
 
 (cl-defun org-srs-item-card-hide (&optional (side :back))


### PR DESCRIPTION
G'day, love the package. 

This is a tiny PR to allow for inline images to be shown when revealing a card. I use this quite a lot for cards like "A plot of velocity vs force for a static friction looks like:". 

I haven't needed to extend this for cloze cards, but I'd be happy to also add this for the cloze lib for completeness.  

Cheers!